### PR TITLE
fix: move msw to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,8 +90,10 @@
     "start": "esno src/index.ts",
     "test": "vitest"
   },
+  "peerDependencies": {
+    "msw": "^2.0.8"
+  },
   "dependencies": {
-    "msw": "^2.0.8",
     "unimport": "^3.7.1",
     "unplugin": "^1.5.0"
   },


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the dependencies. The most important change is the movement of the `msw` package from `dependencies` to `peerDependencies`.

Dependency management:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R93-L94): Moved `msw` package from `dependencies` to `peerDependencies`.